### PR TITLE
Hero remain collapsed on page refresh

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -2,24 +2,25 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { IoMdCloseCircle } from "react-icons/io";
 
-const close = (isVisible, setIsVisible) => {
-  setIsVisible(!isVisible);
+const close = (isClosed, setIsClosed) => {
+  localStorage.setItem('verifactHeroClosed', true);
+  setIsClosed(!isClosed);
 }
 
 export default function Hero(props) {
-  const [isVisible, setIsVisible] = useState(true)
+  const [isClosed, setIsClosed] = useState(localStorage.getItem('verifactHeroClosed') === 'true')
   const welcomeTitle = "Your home for verifying credible news"
   const welcomeContent = "Post a question to our community of news sleuths to get answers and new perspectives about the news your reading"
 
-  return <>{isVisible ? (<Wrapper>
+  return <>{isClosed ? null : (<Wrapper>
     <HeaderWrapper>
-      <Button onClick={() => close(isVisible, setIsVisible)}><CustomIoMdCloseCircle /></Button>
+      <Button onClick={() => close(isClosed, setIsClosed)}><CustomIoMdCloseCircle /></Button>
     </HeaderWrapper>
     <ContentWrapper>
       <Title>{welcomeTitle}</Title>
       <BodyText>{welcomeContent}</BodyText>
     </ContentWrapper>
-  </Wrapper>) : null}</>
+  </Wrapper>)}</>
     ;
 }
 

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -10,7 +10,7 @@ export default function Hero(props) {
   const welcomeContent = "Post a question to our community of news sleuths to get answers and new perspectives about the news your reading"
 
   const close = () => {
-    setLocalData('verifactHeroClosed', 'true')
+    setLocalData('verifactHeroClosed', true)
     setIsClosed(true);
   }
 

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -2,19 +2,20 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { IoMdCloseCircle } from "react-icons/io";
 
-const close = (isClosed, setIsClosed) => {
-  localStorage.setItem('verifactHeroClosed', true);
-  setIsClosed(!isClosed);
-}
-
 export default function Hero(props) {
-  const [isClosed, setIsClosed] = useState(localStorage.getItem('verifactHeroClosed') === 'true')
+  const verifactHeroClosed = JSON.parse(localStorage.getItem('verifactHeroClosed')) ? true : false;
+  const [isClosed, setIsClosed] = useState(verifactHeroClosed)
   const welcomeTitle = "Your home for verifying credible news"
   const welcomeContent = "Post a question to our community of news sleuths to get answers and new perspectives about the news your reading"
 
+  const close = () => {
+    localStorage.setItem('verifactHeroClosed', 'true');
+    setIsClosed(!isClosed);
+  }
+
   return <>{isClosed ? null : (<Wrapper>
     <HeaderWrapper>
-      <Button onClick={() => close(isClosed, setIsClosed)}><CustomIoMdCloseCircle /></Button>
+      <Button onClick={close}><CustomIoMdCloseCircle /></Button>
     </HeaderWrapper>
     <ContentWrapper>
       <Title>{welcomeTitle}</Title>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -2,15 +2,16 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { IoMdCloseCircle } from "react-icons/io";
 
+import { setLocalData, getLocalData } from "../utils/localdata"
+
 export default function Hero(props) {
-  const verifactHeroClosed = JSON.parse(localStorage.getItem('verifactHeroClosed')) ? true : false;
-  const [isClosed, setIsClosed] = useState(verifactHeroClosed)
+  const [isClosed, setIsClosed] = useState(getLocalData('verifactHeroClosed'))
   const welcomeTitle = "Your home for verifying credible news"
   const welcomeContent = "Post a question to our community of news sleuths to get answers and new perspectives about the news your reading"
 
   const close = () => {
-    localStorage.setItem('verifactHeroClosed', 'true');
-    setIsClosed(!isClosed);
+    setLocalData('verifactHeroClosed', 'true')
+    setIsClosed(true);
   }
 
   return <>{isClosed ? null : (<Wrapper>

--- a/src/utils/localdata.js
+++ b/src/utils/localdata.js
@@ -1,0 +1,16 @@
+export function setLocalData(key, value) {
+    if (!value) return
+    window.localStorage.setItem(
+        key,
+        typeof value == 'string' ? value : JSON.stringify(value)
+    )
+}
+
+export function getLocalData(key) {
+    const item = window.localStorage.getItem(key)
+    return item ? JSON.parse(item) : null
+}
+
+export function removeLocalData(key) {
+    window.localStorage.removeItem(key)
+}


### PR DESCRIPTION
Used `localStorage` to hold visibility states of the hero throughout browser session.

Example of setting & getting localStorage,
```
// Set verifactHeroClosed:  'true'
localStorage.setItem('verifactHeroClosed', true);

// Get verifactHeroClosed
localStorage.getItem('verifactHeroClosed')'
```

