### PR TITLE
Deployment

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -7,11 +7,7 @@
 #   $ gcloud topic gcloudignore
 #
 .gcloudignore
-# If you would like to upload your .git directory, .gitignore file or files
-# from your .gitignore file, remove the corresponding line
-# below:
 .git
+.github
 .gitignore
-
-# Node.js dependencies:
 node_modules/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,11 +1,3 @@
-# This file specifies files that are *not* uploaded to Google Cloud Platform
-# using gcloud. It follows the same syntax as .gitignore, with the addition of
-# "#!include" directives (which insert the entries of the given .gitignore-style
-# file at that point).
-#
-# For more information, run:
-#   $ gcloud topic gcloudignore
-#
 .gcloudignore
 .git
 .github

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build production bundle
         env:
-          REACT_APP_API_HOST: ${{ REACT_APP_API_HOST }}
+          REACT_APP_API_HOST: ${{ secrets.REACT_APP_API_HOST }}
         run: npm run build
 
       - name: Setup Google Cloud SDK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy
+
 on:
   push:
     branches:
       - main
-      - deployment
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+      - deployment
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Load node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install JavaScript dependencies
+        run: npm install
+
+      - name: Compile Relay code
+        run: npm run relay
+
+      - name: Build production bundle
+        env:
+          REACT_APP_API_HOST: ${{ REACT_APP_API_HOST }}
+        run: npm run build
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Deploy to App Engine
+        run: gcloud app deploy --quiet

--- a/app.yaml
+++ b/app.yaml
@@ -6,7 +6,9 @@ handlers:
   - url: /(.*\..+)$
     static_files: build/\1
     upload: build/(.*\..+)$
+    secure: always
 
   - url: /.*
     static_files: build/index.html
     upload: build/index.html
+    secure: always

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,12 @@
+service: verifact-frontend
+
+runtime: nodejs14
+
+handlers:
+  - url: /(.*\..+)$
+    static_files: build/\1
+    upload: build/(.*\..+)$
+
+  - url: /.*
+    static_files: build/index.html
+    upload: build/index.html


### PR DESCRIPTION
Adds deployment script to deploy the react app to Google App Engine. `REACT_APP_API_HOST` is saved in an environment variable so that we can easily swap it out once we set up DNS for the API. The app is already viewable at https://verifact-frontend-dot-verifact-300309.df.r.appspot.com/, nothing from the API will load because this domain is not whitelisted. Will wait until DNS is all set up to finish the backend <-> frontend configs. 