### PR TITLE
update login and logout flow

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -23,10 +23,11 @@ export default (props) => {
         style={{ backgroundColor: 'white' }}
       >
         <Nav style={{ alignItems: 'center' }}>
+          {authValue.isLoggedIn?<NavLink>Hi, <u>User</u></NavLink>:<></>}
           <NavLink target='blank' href='https://forms.gle/tVzucdnhb6p5p2pRA'>Share Feedback</NavLink>
 
           {authValue.isLoggedIn
-            ? <NavLink onClick={handleLogOut}>Log Out</NavLink>
+            ? <NavLink href='/' onClick={handleLogOut}>Log Out</NavLink>
             : (
               <>
                 <NavLink href='/login'>Log In</NavLink>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -23,7 +23,7 @@ export default (props) => {
         style={{ backgroundColor: 'white' }}
       >
         <Nav style={{ alignItems: 'center' }}>
-          {authValue.isLoggedIn?<NavLink>Hi, <u>User</u></NavLink>:<></>}
+          {authValue.isLoggedIn ? <NavLink>Hi, <u>User</u></NavLink> : <></>}
           <NavLink target='blank' href='https://forms.gle/tVzucdnhb6p5p2pRA'>Share Feedback</NavLink>
 
           {authValue.isLoggedIn

--- a/src/components/QuestionCard.js
+++ b/src/components/QuestionCard.js
@@ -47,11 +47,11 @@ function QuestionCard ({ question }) {
   const authValue = React.useContext(AuthContext)
 
   const onClickShowForm = (opinion) => {
-    if(authValue.isLoggedIn){
+    if (authValue.isLoggedIn) {
       show = true
       history.push({ pathname: `/question/${id}`, state: show, choice: opinion })
-    }else {
-      history.push({ pathname: `/login`})
+    } else {
+      history.push({ pathname: '/login' })
     }
   }
 

--- a/src/components/QuestionCard.js
+++ b/src/components/QuestionCard.js
@@ -9,6 +9,7 @@ import { Text } from '../styles'
 import { monthDayYear } from '../utils/datetime'
 import OpenGraphMeta from './OpenGraphMeta'
 import QuestionCardAnswersCount from './QuestionCardAnswersCount'
+import { AuthContext } from '../context/Auth'
 
 const Wrap = styled.div`
   padding-bottom: 3rem;
@@ -43,10 +44,15 @@ function QuestionCard ({ question }) {
   const dt = new Date(createdAt)
   const formattedCreatedAt = monthDayYear.format(dt)
   let show = false
+  const authValue = React.useContext(AuthContext)
 
   const onClickShowForm = (opinion) => {
-    show = true
-    history.push({ pathname: `/question/${id}`, state: show, choice: opinion })
+    if(authValue.isLoggedIn){
+      show = true
+      history.push({ pathname: `/question/${id}`, state: show, choice: opinion })
+    }else {
+      history.push({ pathname: `/login`})
+    }
   }
 
   return (

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -23,12 +23,14 @@ function _validateInput (input, required, setErrors) {
 }
 
 function useForm ({
+  setValue,
   mutation,
   vars,
   defaultInput,
   required = [],
   afterSubmit,
   massageInput,
+  placeholder,
   noResetOnSubmit
 }) {
   const notification = useContext(NotificationContext)
@@ -62,6 +64,18 @@ function useForm ({
     setInput(newInput)
   }
 
+  function handleChangeForPlaceholder (e) {
+    const { name, value } = e.target
+    const newInput = Object.assign({}, input)
+    newInput[name] = value
+    if (!value.includes(placeholder)) {
+      setValue(placeholder + value)
+    } else {
+      setValue(value)
+    }
+    setInput(newInput)
+  }
+
   async function handleSubmit (e) {
     e && e.preventDefault && e.preventDefault()
     if (isLoading || !validateInput()) return
@@ -89,7 +103,8 @@ function useForm ({
     isLoading,
     isChanged: !isEqual(defaultInput, input),
     handleChange,
-    handleSubmit
+    handleSubmit,
+    handleChangeForPlaceholder
   }
 }
 

--- a/src/views/AskQuestion.js
+++ b/src/views/AskQuestion.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import graphql from 'babel-plugin-relay/macro'
 import { useHistory } from 'react-router-dom'
 
@@ -19,12 +19,16 @@ const mutation = graphql`
 
 function AskQuestion () {
   const history = useHistory()
+  const [value, setValue] = useState('')
   const {
     errors,
+    handleChangeForPlaceholder,
     handleChange,
     handleSubmit,
     isLoading
   } = useForm({
+    placeholder: 'Is it true that ',
+    setValue,
     mutation,
     defaultInput: {
       text: '',
@@ -55,7 +59,9 @@ function AskQuestion () {
         id='text'
         name='text'
         label='Question'
-        onChange={handleChange}
+        value={value}
+        placeholder='Is it true that'
+        onChange={handleChangeForPlaceholder}
         error={errors.text}
         as='textarea'
         rows={3}

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -32,7 +32,7 @@ const Login = ({ history }) => {
     required: ['username', 'password'],
     afterSubmit: res => {
       value.logIn(res.tokenAuth.token)
-      history.push('/')
+      history.goBack()
     }
   })
 

--- a/src/views/Question.js
+++ b/src/views/Question.js
@@ -41,11 +41,11 @@ export default function Question (props) {
   }, [props.location.state, props.location.choice, props.location])
 
   function open () {
-    if(authValue.isLoggedIn){
+    if (authValue.isLoggedIn) {
       setShowAnswerForm(true)
       setAnswerChoice('True')
     } else {
-      history.push({ pathname: `/login`})
+      history.push({ pathname: '/login' })
     }
   }
 

--- a/src/views/Question.js
+++ b/src/views/Question.js
@@ -7,6 +7,8 @@ import QuestionCard from '../components/QuestionCard'
 import SubmitAnswerForm from '../components/SubmitAnswerForm'
 import AnswerCard from '../components/AnswerCard'
 import { Text, Button } from '../styles'
+import { AuthContext } from '../context/Auth'
+import { useHistory } from 'react-router-dom'
 
 const query = graphql`
   query QuestionQuery($questionId: ID!) {
@@ -30,14 +32,21 @@ export default function Question (props) {
   const questionId = props.match.params.id
   const [showAnswerForm, setShowAnswerForm] = useState(false)
   const [answerChoice, setAnswerChoice] = useState('True')
+  const authValue = React.useContext(AuthContext)
+  const history = useHistory()
+
   useEffect(() => {
     setShowAnswerForm(props.location.state)
     setAnswerChoice(props.location.choice)
   }, [props.location.state, props.location.choice, props.location])
 
   function open () {
-    setShowAnswerForm(true)
-    setAnswerChoice('True')
+    if(authValue.isLoggedIn){
+      setShowAnswerForm(true)
+      setAnswerChoice('True')
+    } else {
+      history.push({ pathname: `/login`})
+    }
   }
 
   function close () {


### PR DESCRIPTION
Context: User feedback that they only realize that they need to login/signup on submitting their question. We should inform them before it.

Changes:
1) Bring users who are not logged in to the login page when they click on 'answer the question' button and 3 reaction buttons
2) Add Hi username when user logged in (need graphql help here - not done yet)


![image](https://user-images.githubusercontent.com/40466889/134793945-9ee846db-5d9d-4a44-ab13-b8c3f2528490.png)
